### PR TITLE
Rework: Opt for class based implementation instead of top-level function

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,155 +1,190 @@
+"""Main entry point used as example documentation and for debugging."""
+
 # pylint: disable=missing-function-docstring,missing-module-docstring
 import logging
-from pycronie import (
-    cron,
-    run_cron,
-    reboot,
-    startup,
-    shutdown,
-    minutely,
-    hourly,
-    midnight,
-    daily,
-    weekly,
-    monthly,
-    annually,
-    yearly,
-)
+from pycronie import Cron, CronScheduler
 
 log = logging.getLogger(__name__)
 FORMAT = "%(asctime)-15s|%(levelname)s|%(name)s: %(message)s"
 logging.basicConfig(format=FORMAT, level=logging.INFO, datefmt="%Y-%m-%d %H:%M:%S")
 
+cron = Cron()
 
-@reboot
+
+@cron.reboot
 async def reboot_() -> None:
+    """Run once on startup."""
     log.info(reboot_.__name__)
 
 
-@shutdown
+@cron.shutdown
 async def shutdown_() -> None:
+    """Run once on shutdown."""
     log.info(shutdown_.__name__)
 
 
-@startup
+@cron.startup
 async def startup_() -> None:
+    """Run once on startup."""
     log.info(startup_.__name__)
 
 
-@minutely
+@cron.minutely
 async def minutely_() -> None:
+    """Run every minute."""
     log.info(minutely_.__name__)
 
 
-@hourly
+@cron.hourly
 async def hourly_() -> None:
+    """Run every hour."""
     log.info(hourly_.__name__)
 
 
-@midnight
+@cron.midnight
 async def midnight_() -> None:
+    """Run every day midnight."""
     log.info(midnight_.__name__)
 
 
-@daily
+@cron.daily
 async def daily_() -> None:
+    """Run once a day."""
     log.info(daily_.__name__)
 
 
-@weekly
+@cron.weekly
 async def weekly_() -> None:
+    """Run once a week."""
     log.info(weekly_.__name__)
 
 
-@monthly
+@cron.monthly
 async def monthly_() -> None:
+    """Run once a month."""
     log.info(monthly_.__name__)
 
 
-@annually
+@cron.annually
 async def anually_() -> None:
+    """Run once a year."""
     log.info(anually_.__name__)
 
 
-@yearly
+@cron.yearly
 async def yearly_() -> None:
+    """Run once a year."""
     log.info(yearly_.__name__)
 
 
-@cron("* * * * *")
+@cron.cron("* * * * *")
 async def every_minute() -> None:
+    """Run once every minute."""
     log.info(every_minute.__name__)
 
 
-@cron("*/2 * * * *")
+@cron.cron("*/2 * * * *")
 async def every_other_minute() -> None:
+    """Run once every even minute."""
     log.info(every_other_minute.__name__)
 
 
-@cron("0 * * * *")
+@cron.cron("0 * * * *")
 async def every_hour() -> None:
+    """Run once an hour at minute 0."""
     log.info(every_hour.__name__)
 
 
-@cron("50 * * * *")
+@cron.cron("50 * * * *")
 async def every_hour2() -> None:
+    """Run once an hour at minute 50."""
     log.info(every_hour2.__name__)
 
 
-@cron("* 2 * * *")
+@cron.cron("* 2 * * *")
 async def mornig() -> None:
+    """Run every monrning at 2 am."""
     log.info(mornig.__name__)
 
 
-@cron("* 20 * * *")
+@cron.cron("* 20 * * *")
 async def night() -> None:
+    """Run every night at 8 pm."""
     log.info(night.__name__)
 
 
-@cron("0 0 * * *")
+@cron.cron("0 0 * * *")
 async def midnight__() -> None:
+    """Run every night at midnight."""
     log.info(midnight__.__name__)
 
 
-@cron("0 12 * * *")
+@cron.cron("0 12 * * *")
 async def noon() -> None:
+    """Run every day at noon."""
     log.info(noon.__name__)
 
 
-@cron("0 0 1 * *")
+@cron.cron("0 0 1 * *")
 async def fom() -> None:
+    """Run on first of month."""
     log.info(fom.__name__)
 
 
-@cron("0 0 30 * *")
+@cron.cron("0 0 30 * *")
 async def lom() -> None:
+    """Run on last of month on the 30st."""
     log.info(lom.__name__)
 
 
-@cron("0 0 31 * *")
+@cron.cron("0 0 31 * *")
 async def lom2() -> None:
+    """Run on last of month if the last of the month is a 31st."""
     log.info(lom2.__name__)
 
 
-@cron("0 0 1 1 *")
+@cron.cron("0 0 1 1 *")
 async def jan() -> None:
+    """Run on the first of Janurary once."""
     log.info(jan.__name__)
 
 
-@cron("0 0 1 12 *")
+@cron.cron("0 0 1 12 *")
 async def dec() -> None:
+    """Run in december once."""
     log.info(dec.__name__)
 
 
-@cron("0 0 24 12 *")
+@cron.cron("0 0 24 12 *")
 async def christmas() -> None:
+    """Run on Christmas."""
     log.info(christmas.__name__)
 
 
-@cron("0 12 21 1 *")
+@cron.cron("0 12 21 1 *")
 async def all_set() -> None:
+    """Run once on Janurary."""
     log.info(all_set.__name__)
 
 
+class TestClass:
+    """Test class for cusomter scheduler inclusion."""
+
+    def __init__(self) -> None:
+        """Create Test object."""
+        self.it = 0
+        self.scheduler = CronScheduler()
+        self.scheduler.add_cron("* * * * *", self.minutely)
+
+    async def minutely(
+        self,
+    ) -> None:
+        """Test Cron."""
+        print(f"Run it {self.it}")
+        self.it += 1
+
+
 if __name__ == "__main__":
-    run_cron()
+    test_class = TestClass()
+    cron.include_scheduler(test_class.scheduler)
+    cron.run_cron()

--- a/src/pycronie/__init__.py
+++ b/src/pycronie/__init__.py
@@ -22,39 +22,13 @@ The algorithm used reflects that of unix cron where:
 """
 
 from pycronie.cronie import (
-    cron,
-    reboot,
-    startup,
-    shutdown,
-    minutely,
-    hourly,
-    midnight,
-    daily,
-    weekly,
-    monthly,
-    annually,
-    yearly,
-    run_cron,
-    run_cron_async,
+    Cron,
     CronJobInvalid,
-    CronJob,
+    CronScheduler,
 )
 
 __all__ = [
-    "cron",
-    "reboot",
-    "startup",
-    "shutdown",
-    "minutely",
-    "hourly",
-    "midnight",
-    "daily",
-    "weekly",
-    "monthly",
-    "annually",
-    "yearly",
-    "run_cron",
-    "run_cron_async",
     "CronJobInvalid",
-    "CronJob",
+    "Cron",
+    "CronScheduler",
 ]

--- a/src/tests/test_cronie.py
+++ b/src/tests/test_cronie.py
@@ -4,7 +4,7 @@
 from datetime import datetime
 from functools import partial
 import pytest
-from pycronie import CronJob, CronJobInvalid
+from pycronie import CronJob, CronJobInvalid, run_cron_async
 
 
 @pytest.fixture(name="cron_job")
@@ -201,3 +201,10 @@ def test_twice_an_hour(cron_job: partial[CronJob]) -> None:
 def test_leap_year(cron_job: partial[CronJob]) -> None:
     """Test cron job defined on a leap year only executed on the next leap year."""
     assert cron_job("0 0 29 2 *").next_run == datetime(2028, 2, 29, 0, 0, 0)
+
+
+@pytest.mark.asyncio
+async def test_empty_joblist() -> None:
+    """Ensure that run_cron_async terminates gracefully when no cronjobs are registered."""
+    result = await run_cron_async()  # type: ignore
+    assert result is None

--- a/src/tests/test_cronie.py
+++ b/src/tests/test_cronie.py
@@ -4,11 +4,18 @@
 from datetime import datetime
 from functools import partial
 import pytest
-from pycronie import CronJob, CronJobInvalid, run_cron_async
+from pycronie import CronJobInvalid, Cron
+from pycronie.cronie import _CronJob
+
+
+@pytest.fixture(name="cron_runner", scope="session")
+def cron_runner_() -> Cron:
+    """Pytest fixture for a session wide cron runnner."""
+    return Cron()
 
 
 @pytest.fixture(name="cron_job")
-def cron_job_() -> partial[CronJob]:
+def cron_job_() -> partial[_CronJob]:
     """Pytest fixture to retrun a mock instance of the CronJob class with a fixed noop function as call target."""
     mock_dt = datetime(year=2024, month=6, day=15, hour=12, minute=13, second=0)
 
@@ -18,24 +25,24 @@ def cron_job_() -> partial[CronJob]:
     async def _id() -> None:
         pass
 
-    setattr(CronJob, "_get_current_time", _get_mock_time)
-    return partial(CronJob, _id)
+    setattr(_CronJob, "_get_current_time", _get_mock_time)
+    return partial(_CronJob, _id)
 
 
-def test_once(cron_job: partial[CronJob]) -> None:
+def test_once(cron_job: partial[_CronJob]) -> None:
     """Tests once off cron jobs have no date associated."""
     assert cron_job("STARTUP").next_run is None
     assert cron_job("SHUTDOWN").next_run is None
 
 
-def test_minutely(cron_job: partial[CronJob]) -> None:
+def test_minutely(cron_job: partial[_CronJob]) -> None:
     """Test instance of cron job exdcuted each minute."""
     assert cron_job("* * * * *").next_run == datetime(
         year=2024, month=6, day=15, hour=12, minute=14, second=0
     )
 
 
-def test_hourly(cron_job: partial[CronJob]) -> None:
+def test_hourly(cron_job: partial[_CronJob]) -> None:
     """Test different instances of hourly cron jobs."""
     assert cron_job("0 * * * *").next_run == datetime(2024, 6, 15, 13, 0, 0)
     assert cron_job("13 * * * *").next_run == datetime(2024, 6, 15, 13, 13, 0)
@@ -43,7 +50,7 @@ def test_hourly(cron_job: partial[CronJob]) -> None:
     assert cron_job("59 * * * *").next_run == datetime(2024, 6, 15, 12, 59, 0)
 
 
-def test_daily(cron_job: partial[CronJob]) -> None:
+def test_daily(cron_job: partial[_CronJob]) -> None:
     """Test different instances of daily cron jobs."""
     assert cron_job("* 0 * * *").next_run == datetime(2024, 6, 16, 0, 0, 0)
     assert cron_job("* 12 * * *").next_run == datetime(2024, 6, 15, 12, 14, 0)
@@ -56,7 +63,7 @@ def test_daily(cron_job: partial[CronJob]) -> None:
     assert cron_job("0 12 15 * *").next_run == datetime(2024, 7, 15, 12, 0, 0)
 
 
-def test_once_a_month(cron_job: partial[CronJob]) -> None:
+def test_once_a_month(cron_job: partial[_CronJob]) -> None:
     """Test different instances of monthly cron jobs."""
     assert cron_job("12 12 1 * *").next_run == datetime(2024, 7, 1, 12, 12, 0)
     assert cron_job("* * 1 * *").next_run == datetime(2024, 7, 1, 0, 0, 0)
@@ -65,13 +72,13 @@ def test_once_a_month(cron_job: partial[CronJob]) -> None:
     assert cron_job("15 14 1 * *").next_run == datetime(2024, 7, 1, 14, 15, 0)
 
 
-def test_monthly(cron_job: partial[CronJob]) -> None:
+def test_monthly(cron_job: partial[_CronJob]) -> None:
     """Test different instances of cron jobs run only on a single month."""
     assert cron_job("* * * 1 *").next_run == datetime(2025, 1, 1, 0, 0, 0)
     assert cron_job("* * * 12 *").next_run == datetime(2024, 12, 1, 0, 0, 0)
 
 
-def test_fixed_datetime(cron_job: partial[CronJob]) -> None:
+def test_fixed_datetime(cron_job: partial[_CronJob]) -> None:
     """Test different instances of cron jobs with exact timinings."""
     assert cron_job("42 23 24 12 *").next_run == datetime(2024, 12, 24, 23, 42, 0)
     assert cron_job("1 1 1 1 *").next_run == datetime(2025, 1, 1, 1, 1, 0)
@@ -79,26 +86,26 @@ def test_fixed_datetime(cron_job: partial[CronJob]) -> None:
     assert cron_job("30 8 15 6 *").next_run == datetime(2025, 6, 15, 8, 30, 0)
 
 
-def test_day_range(cron_job: partial[CronJob]) -> None:
+def test_day_range(cron_job: partial[_CronJob]) -> None:
     """Test different instances of cron jobs with range definitions."""
     assert cron_job("0 4 8-14 * *").next_run == datetime(2024, 7, 8, 4, 0, 0)
     assert cron_job("0 4 1-3 * *").next_run == datetime(2024, 7, 1, 4, 0, 0)
     assert cron_job("0 4 20-22 * *").next_run == datetime(2024, 6, 20, 4, 0, 0)
 
 
-def test_hour_range(cron_job: partial[CronJob]) -> None:
+def test_hour_range(cron_job: partial[_CronJob]) -> None:
     """Test different instances of cron jobs with range definitions."""
     assert cron_job("* 1-5 * * *").next_run == datetime(2024, 6, 16, 1, 0, 0)
     assert cron_job("* 9-17 * * *").next_run == datetime(2024, 6, 15, 12, 14, 0)
     assert cron_job("* 20-22 * * *").next_run == datetime(2024, 6, 15, 20, 0, 0)
 
 
-def test_minute_range(cron_job: partial[CronJob]) -> None:
+def test_minute_range(cron_job: partial[_CronJob]) -> None:
     """Test different instances of cron jobs with range definitions."""
     assert cron_job("5-10 * * * *").next_run == datetime(2024, 6, 15, 13, 5, 0)
 
 
-def test_invalid_strings(cron_job: partial[CronJob]) -> None:
+def test_invalid_strings(cron_job: partial[_CronJob]) -> None:
     """Test different instances of cron jobs with invalid inputs."""
     with pytest.raises(CronJobInvalid):
         cron_job("/5 * * * *")
@@ -154,13 +161,13 @@ def test_invalid_strings(cron_job: partial[CronJob]) -> None:
         cron_job("0 0 1W * *")  # `1W` (nearest weekday) is not supported by all parsers
 
 
-def test_minute_step(cron_job: partial[CronJob]) -> None:
+def test_minute_step(cron_job: partial[_CronJob]) -> None:
     """Test different instances of cron jobs with step definitions."""
     assert cron_job("*/5 * * * *").next_run == datetime(2024, 6, 15, 12, 15, 0)
     assert cron_job("5-20/5 * * * *").next_run == datetime(2024, 6, 15, 12, 15, 0)
 
 
-def test_weekday(cron_job: partial[CronJob]) -> None:
+def test_weekday(cron_job: partial[_CronJob]) -> None:
     """Test different instances of cron jobs with weekday definitions."""
     assert cron_job("* * * * 1").next_run == datetime(2024, 6, 17, 0, 0, 0)
     assert cron_job("* * * * 6").next_run == datetime(2024, 6, 15, 12, 14, 0)
@@ -180,25 +187,25 @@ def test_weekday(cron_job: partial[CronJob]) -> None:
     assert cron_job("* * * * 2/3").next_run == datetime(2024, 6, 18, 0, 0, 0)
 
 
-def test_fixed_time(cron_job: partial[CronJob]) -> None:
+def test_fixed_time(cron_job: partial[_CronJob]) -> None:
     """Test different instances of cron jobs with a fixed time."""
     assert cron_job("5 12 * * *").next_run == datetime(2024, 6, 16, 12, 5, 0)
     assert cron_job("20 12 * * *").next_run == datetime(2024, 6, 15, 12, 20, 0)
     assert cron_job("0 0 * * *").next_run == datetime(2024, 6, 16, 0, 0, 0)
 
 
-def test_step_minute(cron_job: partial[CronJob]) -> None:
+def test_step_minute(cron_job: partial[_CronJob]) -> None:
     """Test different instances of cron jobs with a step definition."""
     assert cron_job("*/2 * * * *").next_run == datetime(2024, 6, 15, 12, 14, 0)
     assert cron_job("*/15 * * * *").next_run == datetime(2024, 6, 15, 12, 15, 0)
 
 
-def test_twice_an_hour(cron_job: partial[CronJob]) -> None:
+def test_twice_an_hour(cron_job: partial[_CronJob]) -> None:
     """Test different instances of cron jobs with a comma definition."""
     assert cron_job("15,45 12 * * *").next_run == datetime(2024, 6, 15, 12, 15, 0)
 
 
-def test_leap_year(cron_job: partial[CronJob]) -> None:
+def test_leap_year(cron_job: partial[_CronJob]) -> None:
     """Test cron job defined on a leap year only executed on the next leap year."""
     assert cron_job("0 0 29 2 *").next_run == datetime(2028, 2, 29, 0, 0, 0)
 
@@ -206,5 +213,6 @@ def test_leap_year(cron_job: partial[CronJob]) -> None:
 @pytest.mark.asyncio
 async def test_empty_joblist() -> None:
     """Ensure that run_cron_async terminates gracefully when no cronjobs are registered."""
-    result = await run_cron_async()  # type: ignore
+    cron_runner = Cron()
+    result = await cron_runner.run_cron_async()  # type: ignore
     assert result is None


### PR DESCRIPTION
This is the only sane way so far to allow for corn jobs defined in class. When using decorators, the corn function is not yet bound to an object when executing the decorator; thus, we cannot schedule the job since we are missing the object.

Choose this over metaclasses since it's the only way to reliably tell weather a function is part of  a class or not. Alternativley we need to relay on func.__qualname__. 

This allows us to have a better high level interface to include additional scheduler similar to openapi's include_router API.