### PR TITLE
Crest42/storage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     hooks:
     - id: flake8
       additional_dependencies: [flake8-docstrings]
-      args: ["--ignore=E501,E203"]
+      args: ["--ignore=E501,E203,E704"]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: 'v1.14.1'
     hooks:

--- a/.pylintrc
+++ b/.pylintrc
@@ -190,7 +190,8 @@ function-naming-style=snake_case
 #function-rgx=
 
 # Good variable names which should always be accepted, separated by a comma.
-good-names=i,
+good-names=T1, T2,
+           i,
            j,
            k,
            ex,

--- a/poetry.lock
+++ b/poetry.lock
@@ -49,18 +49,18 @@ tests-mypy = ["mypy (>=1.11.1)", "pytest-mypy-plugins"]
 
 [[package]]
 name = "babel"
-version = "2.16.0"
+version = "2.17.0"
 description = "Internationalization utilities"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "babel-2.16.0-py3-none-any.whl", hash = "sha256:368b5b98b37c06b7daf6696391c3240c938b37767d4584413e8438c5c435fa8b"},
-    {file = "babel-2.16.0.tar.gz", hash = "sha256:d1f3554ca26605fe173f3de0c65f750f5a42f924499bf134de6423582298e316"},
+    {file = "babel-2.17.0-py3-none-any.whl", hash = "sha256:4d0b53093fdfb4b21c92b5213dba5a1b23885afa8383709427046b21c366e5f2"},
+    {file = "babel-2.17.0.tar.gz", hash = "sha256:0c54cffb19f690cdcc52a3b50bcbf71e07a808d1c80d549f2459b9d2cf0afb9d"},
 ]
 
 [package.extras]
-dev = ["freezegun (>=1.0,<2.0)", "pytest (>=6.0)", "pytest-cov"]
+dev = ["backports.zoneinfo", "freezegun (>=1.0,<2.0)", "jinja2 (>=3.0)", "pytest (>=6.0)", "pytest-cov", "pytz", "setuptools", "tzdata"]
 
 [[package]]
 name = "black"
@@ -111,14 +111,14 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "certifi"
-version = "2024.12.14"
+version = "2025.1.31"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.6"
 groups = ["dev"]
 files = [
-    {file = "certifi-2024.12.14-py3-none-any.whl", hash = "sha256:1275f7a45be9464efc1173084eaa30f866fe2e47d389406136d332ed4967ec56"},
-    {file = "certifi-2024.12.14.tar.gz", hash = "sha256:b650d30f370c2b724812bee08008be0c4163b163ddaec3f2546c1caf65f191db"},
+    {file = "certifi-2025.1.31-py3-none-any.whl", hash = "sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe"},
+    {file = "certifi-2025.1.31.tar.gz", hash = "sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pycronie"
-version = "0.2.1"
+version = "0.3.0"
 description = "A project to manage cron jobs."
 authors = ["Robin Lösch <robin@chilio.net>"]
 license = "MIT"

--- a/src/docs/conf.py
+++ b/src/docs/conf.py
@@ -3,7 +3,6 @@ import sys
 sys.path.insert(0, os.path.abspath('..'))
 
 # pylint: disable-all
-# type: ignore
 # Configuration file for the Sphinx documentation builder.
 #
 # For the full list of built-in configuration values, see the documentation:
@@ -28,7 +27,6 @@ extensions = [
 
 
 templates_path = ["_templates"]
-exclude_patterns = []
 add_module_names = False
 autodoc_member_order = "bysource"
 

--- a/src/main.py
+++ b/src/main.py
@@ -2,7 +2,7 @@
 
 # pylint: disable=missing-function-docstring,missing-module-docstring
 import logging
-from pycronie import Cron, CronScheduler
+from pycronie import Cron, CronScheduler, CronStoreBucket, VoidInputArg
 
 log = logging.getLogger(__name__)
 FORMAT = "%(asctime)-15s|%(levelname)s|%(name)s: %(message)s"
@@ -14,157 +14,194 @@ cron = Cron()
 @cron.reboot
 async def reboot_() -> None:
     """Run once on startup."""
-    log.info(reboot_.__name__)
+    log.info(reboot_)
 
 
 @cron.shutdown
 async def shutdown_() -> None:
     """Run once on shutdown."""
-    log.info(shutdown_.__name__)
+    log.info(shutdown_)
 
 
 @cron.startup
 async def startup_() -> None:
     """Run once on startup."""
-    log.info(startup_.__name__)
+    log.info(startup_)
 
 
 @cron.minutely
 async def minutely_() -> None:
     """Run every minute."""
-    log.info(minutely_.__name__)
+    log.info(minutely_)
 
 
 @cron.hourly
 async def hourly_() -> None:
     """Run every hour."""
-    log.info(hourly_.__name__)
+    log.info(hourly_)
 
 
 @cron.midnight
 async def midnight_() -> None:
     """Run every day midnight."""
-    log.info(midnight_.__name__)
+    log.info(midnight_)
 
 
 @cron.daily
 async def daily_() -> None:
     """Run once a day."""
-    log.info(daily_.__name__)
+    log.info(daily_)
 
 
 @cron.weekly
 async def weekly_() -> None:
     """Run once a week."""
-    log.info(weekly_.__name__)
+    log.info(weekly_)
 
 
 @cron.monthly
 async def monthly_() -> None:
     """Run once a month."""
-    log.info(monthly_.__name__)
+    log.info(monthly_)
 
 
 @cron.annually
 async def anually_() -> None:
     """Run once a year."""
-    log.info(anually_.__name__)
+    log.info(anually_)
 
 
 @cron.yearly
 async def yearly_() -> None:
     """Run once a year."""
-    log.info(yearly_.__name__)
+    log.info(yearly_)
 
 
 @cron.cron("* * * * *")
 async def every_minute() -> None:
     """Run once every minute."""
-    log.info(every_minute.__name__)
+    log.info(every_minute)
 
 
 @cron.cron("*/2 * * * *")
 async def every_other_minute() -> None:
     """Run once every even minute."""
-    log.info(every_other_minute.__name__)
+    log.info(every_other_minute)
 
 
 @cron.cron("0 * * * *")
 async def every_hour() -> None:
     """Run once an hour at minute 0."""
-    log.info(every_hour.__name__)
+    log.info(every_hour)
 
 
 @cron.cron("50 * * * *")
 async def every_hour2() -> None:
     """Run once an hour at minute 50."""
-    log.info(every_hour2.__name__)
+    log.info(every_hour2)
 
 
 @cron.cron("* 2 * * *")
 async def mornig() -> None:
     """Run every monrning at 2 am."""
-    log.info(mornig.__name__)
+    log.info(mornig)
 
 
 @cron.cron("* 20 * * *")
 async def night() -> None:
     """Run every night at 8 pm."""
-    log.info(night.__name__)
+    log.info(night)
 
 
 @cron.cron("0 0 * * *")
 async def midnight__() -> None:
     """Run every night at midnight."""
-    log.info(midnight__.__name__)
+    log.info(midnight__)
 
 
 @cron.cron("0 12 * * *")
 async def noon() -> None:
     """Run every day at noon."""
-    log.info(noon.__name__)
+    log.info(noon)
 
 
 @cron.cron("0 0 1 * *")
 async def fom() -> None:
     """Run on first of month."""
-    log.info(fom.__name__)
+    log.info(fom)
 
 
 @cron.cron("0 0 30 * *")
 async def lom() -> None:
     """Run on last of month on the 30st."""
-    log.info(lom.__name__)
+    log.info(lom)
 
 
 @cron.cron("0 0 31 * *")
 async def lom2() -> None:
     """Run on last of month if the last of the month is a 31st."""
-    log.info(lom2.__name__)
+    log.info(lom2)
 
 
 @cron.cron("0 0 1 1 *")
 async def jan() -> None:
     """Run on the first of Janurary once."""
-    log.info(jan.__name__)
+    log.info(jan)
 
 
 @cron.cron("0 0 1 12 *")
 async def dec() -> None:
     """Run in december once."""
-    log.info(dec.__name__)
+    log.info(dec)
 
 
 @cron.cron("0 0 24 12 *")
 async def christmas() -> None:
     """Run on Christmas."""
-    log.info(christmas.__name__)
+    log.info(christmas)
 
 
 @cron.cron("0 12 21 1 *")
 async def all_set() -> None:
     """Run once on Janurary."""
-    log.info(all_set.__name__)
+    log.info(all_set)
+
+
+@cron.cron("* * 31 2,4,6,9,11 *")
+async def invalid_day_of_month() -> None:
+    """Only run on even months on day 31 -> impossible."""
+
+
+@cron.cron("* * * * *")
+async def all_set_with_arg(storage_bucket: CronStoreBucket) -> None:
+    """Run minutely with storage."""
+    if not storage_bucket.foo:
+        storage_bucket.foo = 1
+    else:
+        storage_bucket.foo += 1
+    log.info(f"all_set_with_arg: {storage_bucket.foo}")
+
+
+@cron.cron("* * * * *")
+async def all_set_with_arg2(
+    storage_bucket: CronStoreBucket, void: VoidInputArg
+) -> None:
+    """Run minutely with storage and void arg."""
+    if not storage_bucket.foo:
+        storage_bucket.foo = 1
+    else:
+        storage_bucket.foo += 1
+    log.info(f"all_set_with_arg2: {storage_bucket.foo} {void}")
+
+
+@cron.minutely
+async def all_set_with_arg_minutely(storage_bucket: CronStoreBucket) -> None:
+    """Run minutely with storage."""
+    if not storage_bucket.foo:
+        storage_bucket.foo = 1
+    else:
+        storage_bucket.foo += 1
+    log.info(f"all_set_with_arg_minutely: {storage_bucket.foo}")
 
 
 class TestClass:
@@ -182,6 +219,36 @@ class TestClass:
         """Test Cron."""
         print(f"Run it {self.it}")
         self.it += 1
+
+
+@cron.startup
+async def valid_arg(storage_bucket: CronStoreBucket) -> None:
+    """Run every minute."""
+    if storage_bucket.run is None:
+        storage_bucket.run = 1
+    else:
+        storage_bucket.run += 1
+    log.info(f"{valid_arg}: {storage_bucket.run}")
+
+
+@cron.startup
+async def valid_arg2(storage_bucket: CronStoreBucket, void: VoidInputArg) -> None:
+    """Run every minute."""
+    if storage_bucket.run is None:
+        storage_bucket.run = 1
+    else:
+        storage_bucket.run += 1
+    log.info(f"{valid_arg}: {storage_bucket.run} {void}")
+
+
+@cron.startup
+async def valid_arg3(void: VoidInputArg, storage_bucket: CronStoreBucket) -> None:
+    """Run every minute."""
+    if storage_bucket.run is None:
+        storage_bucket.run = 1
+    else:
+        storage_bucket.run += 1
+    log.info(f"{valid_arg}: {storage_bucket.run} {void}")
 
 
 if __name__ == "__main__":

--- a/src/main.py
+++ b/src/main.py
@@ -2,7 +2,7 @@
 
 # pylint: disable=missing-function-docstring,missing-module-docstring
 import logging
-from pycronie import Cron, CronScheduler, CronStoreBucket, VoidInputArg
+from pycronie import Cron, CronScheduler, CronCache, VoidInputArg
 
 log = logging.getLogger(__name__)
 FORMAT = "%(asctime)-15s|%(levelname)s|%(name)s: %(message)s"
@@ -173,35 +173,33 @@ async def invalid_day_of_month() -> None:
 
 
 @cron.cron("* * * * *")
-async def all_set_with_arg(storage_bucket: CronStoreBucket) -> None:
-    """Run minutely with storage."""
-    if not storage_bucket.foo:
-        storage_bucket.foo = 1
+async def all_set_with_arg(cache: CronCache) -> None:
+    """Run minutely with cache."""
+    if not cache.foo:
+        cache.foo = 1
     else:
-        storage_bucket.foo += 1
-    log.info(f"all_set_with_arg: {storage_bucket.foo}")
+        cache.foo += 1
+    log.info(f"all_set_with_arg: {cache.foo}")
 
 
 @cron.cron("* * * * *")
-async def all_set_with_arg2(
-    storage_bucket: CronStoreBucket, void: VoidInputArg
-) -> None:
-    """Run minutely with storage and void arg."""
-    if not storage_bucket.foo:
-        storage_bucket.foo = 1
+async def all_set_with_arg2(cache: CronCache, void: VoidInputArg) -> None:
+    """Run minutely with cache and void arg."""
+    if not cache.foo:
+        cache.foo = 1
     else:
-        storage_bucket.foo += 1
-    log.info(f"all_set_with_arg2: {storage_bucket.foo} {void}")
+        cache.foo += 1
+    log.info(f"all_set_with_arg2: {cache.foo} {void}")
 
 
 @cron.minutely
-async def all_set_with_arg_minutely(storage_bucket: CronStoreBucket) -> None:
-    """Run minutely with storage."""
-    if not storage_bucket.foo:
-        storage_bucket.foo = 1
+async def all_set_with_arg_minutely(cache: CronCache) -> None:
+    """Run minutely with cache."""
+    if not cache.foo:
+        cache.foo = 1
     else:
-        storage_bucket.foo += 1
-    log.info(f"all_set_with_arg_minutely: {storage_bucket.foo}")
+        cache.foo += 1
+    log.info(f"all_set_with_arg_minutely: {cache.foo}")
 
 
 class TestClass:
@@ -222,33 +220,33 @@ class TestClass:
 
 
 @cron.startup
-async def valid_arg(storage_bucket: CronStoreBucket) -> None:
+async def valid_arg(cache: CronCache) -> None:
     """Run every minute."""
-    if storage_bucket.run is None:
-        storage_bucket.run = 1
+    if cache.run is None:
+        cache.run = 1
     else:
-        storage_bucket.run += 1
-    log.info(f"{valid_arg}: {storage_bucket.run}")
+        cache.run += 1
+    log.info(f"{valid_arg}: {cache.run}")
 
 
 @cron.startup
-async def valid_arg2(storage_bucket: CronStoreBucket, void: VoidInputArg) -> None:
+async def valid_arg2(cache: CronCache, void: VoidInputArg) -> None:
     """Run every minute."""
-    if storage_bucket.run is None:
-        storage_bucket.run = 1
+    if cache.run is None:
+        cache.run = 1
     else:
-        storage_bucket.run += 1
-    log.info(f"{valid_arg}: {storage_bucket.run} {void}")
+        cache.run += 1
+    log.info(f"{valid_arg}: {cache.run} {void}")
 
 
 @cron.startup
-async def valid_arg3(void: VoidInputArg, storage_bucket: CronStoreBucket) -> None:
+async def valid_arg3(void: VoidInputArg, cache: CronCache) -> None:
     """Run every minute."""
-    if storage_bucket.run is None:
-        storage_bucket.run = 1
+    if cache.run is None:
+        cache.run = 1
     else:
-        storage_bucket.run += 1
-    log.info(f"{valid_arg}: {storage_bucket.run} {void}")
+        cache.run += 1
+    log.info(f"{valid_arg}: {cache.run} {void}")
 
 
 if __name__ == "__main__":

--- a/src/pycronie/__init__.py
+++ b/src/pycronie/__init__.py
@@ -26,10 +26,14 @@ from pycronie.cronie import (
     Cron,
     CronJobInvalid,
     CronScheduler,
+    CronStoreBucket,
+    VoidInputArg,
 )
 
 __all__ = [
     "CronJobInvalid",
     "Cron",
     "CronScheduler",
+    "CronStoreBucket",
+    "VoidInputArg",
 ]

--- a/src/pycronie/__init__.py
+++ b/src/pycronie/__init__.py
@@ -26,7 +26,7 @@ from pycronie.cronie import (
     Cron,
     CronJobInvalid,
     CronScheduler,
-    CronStoreBucket,
+    CronCache,
     VoidInputArg,
 )
 
@@ -34,6 +34,6 @@ __all__ = [
     "CronJobInvalid",
     "Cron",
     "CronScheduler",
-    "CronStoreBucket",
+    "CronCache",
     "VoidInputArg",
 ]


### PR DESCRIPTION
Support for cron-level data caching and class-level annotations:
- Add CronStorageBucket class that can be annotated on a cron jobs function definition to support reusable storage in between executions
- Added typing support for cron jobs with zero, one, or two arguments of type _CronInputArg. e.g. CronStorageBucket. This allows us to flag cron jobs with invalid function parameters that were wrongly typed. Sadly we had to do some overload magic here because of a sane way to implement this with native Python typing support
- Added support for "schedulers". This allows us to annotate class methods using a scheduler per class and add the scheduler to the main cron implementation after the object is created. By default, the Cron implementation uses one scheduler for all annotated functions